### PR TITLE
Add experimental support for persistent authentication and key storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Fuck off windows
 **/Thumbs.db
+muteSources.json

--- a/js/cryptodog.js
+++ b/js/cryptodog.js
@@ -924,7 +924,7 @@ var handleNotificationTimeout = function() {
 	}, this);
 }
 
-window.setInterval(handleNotificationTimeout, 1000);
+window.setInterval(handleNotificationTimeout, 60000);
 
 function notificationTruncate(msg) {
    // Chrome truncates its notifications on its own, but firefox doesn't for some reason

--- a/js/cryptodog.js
+++ b/js/cryptodog.js
@@ -25,6 +25,9 @@ Cryptodog.me = {
 
 Cryptodog.buddies = {}
 
+// For persistent authentication.
+Cryptodog.authList = {}
+
 // For persistent ignores.
 Cryptodog.ignoredNicknames = []
 
@@ -81,6 +84,30 @@ GLOBAL INTERFACE FUNCTIONS
 Cryptodog.isFiltered = function(name) {
 	return false;
 }
+
+// Stores list of authenticated buddies with associated fingerprints.
+Cryptodog.storeAuthList = function() {
+	if (!Cryptodog.persist) {
+		return;
+	}
+
+	Cryptodog.storage.setItem("authList", Cryptodog.authList);
+}
+
+// Load persistence
+Cryptodog.storage.getItem('persistenceEnabled', function(e) {
+	if (e) {
+		Cryptodog.persist = true;
+
+		Cryptodog.storage.getItem('authList', function(al) {
+			var a = al || {};
+			Cryptodog.authList = a;
+		});
+
+	} else {
+		Cryptodog.persist = false;
+	}
+});
 
 // Update a file transfer progress bar.
 Cryptodog.updateFileProgressBar = function(file, chunk, size, recipient) {
@@ -295,8 +322,27 @@ Buddy.prototype = {
 		this.mpFingerprint = Cryptodog.multiParty.genFingerprint(this.nickname);
 		this.mpSecretKey = Cryptodog.multiParty.genSharedSecret(this.nickname);
 	},
-	updateAuth: function(auth) {
+	updateAuth: function(auth, dontTouchList) {
 		var nickname = this.nickname;
+		var bd = this;
+
+		if (Cryptodog.persist) {
+			if (!dontTouchList) {
+				if (auth) {
+					ensureOTRdialog(nickname, false, function() {
+						Cryptodog.authList[nickname] = {
+							mp:  bd.mpFingerprint,
+							otr: bd.fingerprint
+						}
+						Cryptodog.storeAuthList();
+					}, true);
+				} else {
+					delete Cryptodog.authList[this.nickname];
+					Cryptodog.storeAuthList();
+				}
+			}
+		}
+
 		this.authenticated = auth;
 		if (auth) {
 			$('#authenticated').attr('data-active', true);
@@ -375,6 +421,17 @@ Cryptodog.addBuddy = function(nickname, id, status) {
 	}
 	if (!ascii.test(buddy.nickname)) {
 		$('#buddy-' + buddy.id).addClass('warning');
+	}
+
+	if (Cryptodog.persist && Cryptodog.authList[nickname]) {
+			ensureOTRdialog(nickname, false, function() {
+				if (Cryptodog.authList[nickname]) {
+					if (buddy.mpFingerprint == Cryptodog.authList[nickname].mp
+					 && buddy.fingerprint   == Cryptodog.authList[nickname].otr) {
+						buddy.updateAuth(true, true);
+					}
+				}
+			}, true);
 	}
 }
 
@@ -559,6 +616,35 @@ Cryptodog.displayInfo = function(nickname) {
 		}
 		$('#otrFingerprint').text(getFingerprint(nickname, true));
 		$('#multiPartyFingerprint').text(getFingerprint(nickname, false));
+
+		var persist = false;
+
+		Cryptodog.storage.getItem('persistenceEnabled', function(e) {
+			if (e) {
+				Cryptodog.persist = true;
+				$('#optIntoPersistence').prop('checked', true);
+			} else {
+				Cryptodog.persist = false;
+				$('#optIntoPersistence').prop('checked', false);
+			}
+		});
+
+		$('#optIntoPersistence').click(function() {
+			if (Cryptodog.persist) {
+				$('#optIntoPersistence').prop('checked', false);
+				Cryptodog.storage.removeItem('persistenceEnabled');
+				Cryptodog.storage.removeItem('authList');
+				Cryptodog.persist = false;
+			} else {
+				Cryptodog.persist = true;
+				$('#optIntoPersistence').prop('checked', true);
+				Cryptodog.storage.setItem('persistenceEnabled', {
+					'enabled': true,
+					'mp':      BigInt.bigInt2base64(Cryptodog.me.mpPrivateKey, 32),
+					'otr':     Cryptodog.me.otrKey.packPrivate()
+				});
+			}
+		});
 	})
 }
 
@@ -869,20 +955,24 @@ var sendFile = function(nickname) {
 }
 
 // If OTR fingerprints have not been generated, show a progress bar and generate them.
-var ensureOTRdialog = function(nickname, close, cb) {
+var ensureOTRdialog = function(nickname, close, cb, noAnimation) {
 	var buddy = Cryptodog.buddies[nickname];
 	if (nickname === Cryptodog.me.nickname || buddy.fingerprint) {
 		return cb();
 	}
 
-	Cryptodog.UI.progressBarOTR()
+	if (!noAnimation) {
+		Cryptodog.UI.progressBarOTR()
 
-	$('#progressBar').css('margin', '70px auto 0 auto')
-	$('#fill').animate({'width': '100%', 'opacity': '1'}, 10000, 'linear')
+		$('#progressBar').css('margin', '70px auto 0 auto')
+		$('#fill').animate({'width': '100%', 'opacity': '1'}, 10000, 'linear')
+	}
+
 	// add some state for status callback
-	buddy.genFingerState = { close: close, cb: cb }
+	buddy.genFingerState = { close: close, cb: cb, noAnimation: noAnimation}
 	buddy.otr.sendQueryMsg()
 }
+
 
 // Open a buddy's contact list context menu.
 var openBuddyMenu = function(nickname) {

--- a/js/cryptodog.js
+++ b/js/cryptodog.js
@@ -533,6 +533,9 @@ Cryptodog.buddyStatus = function(nickname, status) {
 
 // Handle buddy going offline.
 Cryptodog.removeBuddy = function(nickname) {
+	if (!Cryptodog.buddies[nickname]) {
+		return;
+	}
 	var buddyID = Cryptodog.buddies[nickname].id;
 	var buddyElement = $('.buddy').filterByData('id', buddyID);
 	delete Cryptodog.buddies[nickname];
@@ -699,8 +702,6 @@ Cryptodog.displayInfo = function(nickname) {
 		}
 		$('#otrFingerprint').text(getFingerprint(nickname, true));
 		$('#multiPartyFingerprint').text(getFingerprint(nickname, false));
-
-		var persist = false;
 
 		Cryptodog.storage.getItem('persistenceEnabled', function(e) {
 			if (e) {
@@ -1043,6 +1044,8 @@ var ensureOTRdialog = function(nickname, close, cb, noAnimation) {
 	if (nickname === Cryptodog.me.nickname || buddy.fingerprint) {
 		return cb();
 	}
+
+	noAnimation = noAnimation || false;
 
 	if (!noAnimation) {
 		Cryptodog.UI.progressBarOTR()

--- a/js/etc/otr.js
+++ b/js/etc/otr.js
@@ -39,6 +39,11 @@
             return;
         }
 
+        // Drop messages from unknown users
+        if (!Cryptodog.buddies[nickname]) {
+            return;
+        }
+
         Cryptodog.addToConversation(msg, nickname, Cryptodog.buddies[nickname].id, 'message');
 
         if (Cryptodog.me.currentBuddy !== Cryptodog.buddies[nickname].id && !Cryptodog.buddies[nickname].ignored()) {
@@ -63,6 +68,10 @@
         /*jshint camelcase:false */
         var buddy = Cryptodog.buddies[nickname];
 
+        if (!buddy) {
+            return;
+        }
+
         if (state === OTR.CONST.STATUS_AKE_SUCCESS) {
             var fingerprint = buddy.otr.their_priv_pk.fingerprint();
 
@@ -80,6 +89,9 @@
     // Store received filename.
     var onFile = function(nickname, type, key, filename) {
         var buddy = Cryptodog.buddies[nickname];
+        if (!buddy) {
+            return;
+        }
 
         // filename is being relied on as diversifier
         // and should continue to be generated uniquely
@@ -155,6 +167,10 @@
     var onSMPAnswer = function(nickname, type, data, act) {
         var chatWindow = Cryptodog.locale.chatWindow,
             buddy = Cryptodog.buddies[nickname];
+
+        if (!buddy) {
+            return;
+        }
 
         switch (type) {
             case 'question':

--- a/js/etc/otr.js
+++ b/js/etc/otr.js
@@ -40,7 +40,7 @@
         }
 
         // Drop messages from unknown users
-        if (!Cryptodog.buddies[nickname]) {
+        if (typeof Cryptodog.buddies[nickname] == 'undefined') {
             return;
         }
 

--- a/js/etc/templates.js
+++ b/js/etc/templates.js
@@ -19,6 +19,7 @@ Cryptodog.templates = {
     myInfo:
         '<div class="title">{{nickname}}</div>' +
         '<div id="displayInfo">' +
+        '<input id="optIntoPersistence" type="checkbox"><span>Persist keys locally (this may be dangerous if used improperly).</span></input></br>' +
         '{{groupFingerprint}}<br /><span id="multiPartyFingerprint"></span><br />' +
         '{{otrFingerprint}}<br /><span id="otrFingerprint"></span></div>',
 

--- a/js/etc/templates.js
+++ b/js/etc/templates.js
@@ -19,7 +19,7 @@ Cryptodog.templates = {
     myInfo:
         '<div class="title">{{nickname}}</div>' +
         '<div id="displayInfo">' +
-        '<input id="optIntoPersistence" type="checkbox"><span>Persist keys locally (this may be dangerous if used improperly).</span></input></br>' +
+        '<input id="optIntoPersistence" type="checkbox"><span>Persist keys locally (this may be dangerous if used improperly).</span></input><br/>' +
         '{{groupFingerprint}}<br /><span id="multiPartyFingerprint"></span><br />' +
         '{{otrFingerprint}}<br /><span id="otrFingerprint"></span></div>',
 

--- a/js/etc/ui.js
+++ b/js/etc/ui.js
@@ -66,11 +66,17 @@ Cryptodog.UI = {
     // Close generating fingerprints dialog.
     closeGenerateFingerprints: function(nickname) {
         var state = Cryptodog.buddies[nickname].genFingerState;
-        Cryptodog.buddies[nickname].genFingerState = null;
+
+        if (!state) {
+            return;
+        }
 
         if (state.noAnimation) {
+            Cryptodog.buddies[nickname].genFingerState = null;
             return state.cb();
         }
+
+        Cryptodog.buddies[nickname].genFingerState = null;
 
         $('#fill')
             .stop()

--- a/js/etc/ui.js
+++ b/js/etc/ui.js
@@ -68,6 +68,10 @@ Cryptodog.UI = {
         var state = Cryptodog.buddies[nickname].genFingerState;
         Cryptodog.buddies[nickname].genFingerState = null;
 
+        if (state.noAnimation) {
+            return state.cb();
+        }
+
         $('#fill')
             .stop()
             .animate({ width: '100%', opacity: '1' }, 400, 'linear', function() {

--- a/js/etc/xmpp.js
+++ b/js/etc/xmpp.js
@@ -314,6 +314,12 @@ $(window).ready(function() {
             Cryptodog.removeBuddy(nickname);
             return true;
         } else if (!Cryptodog.buddies.hasOwnProperty(nickname)) {
+            // Don't render user join if it violates mutelist rules.
+            if (Cryptodog.isMutelisted(nickname)) {
+                log("Silently filtered " + nickname);
+                return true;
+            }
+
             // Create buddy element if buddy is new
             Cryptodog.addBuddy(nickname, null, 'online');
             

--- a/js/lib/strophe/strophe.js
+++ b/js/lib/strophe/strophe.js
@@ -719,6 +719,8 @@ if (!root.atob) {
         define('strophe-sha1', [],function () {
             return factory();
         });
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
         // Browser globals
         root.SHA1 = factory();
@@ -913,6 +915,8 @@ return {
         define('strophe-md5',[], function () {
             return factory();
         });
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
         // Browser globals
         root.MD5 = factory();
@@ -1115,6 +1119,8 @@ return {
         define('strophe-utils',[], function () {
             return factory();
         });
+    } else if (typeof exports === 'object') {
+        module.exports = factory();
     } else {
         // Browser globals
         root.stropheUtils = factory();
@@ -1203,6 +1209,12 @@ return {
         ], function () {
             return factory.apply(this, arguments);
         });
+    }  else if (typeof exports === 'object') {
+        module.exports = factory(
+            require('./sha1'),
+            require('./md5'),
+            require('./utils')
+        );
     } else {
         // Browser globals
         var o = factory(root.SHA1, root.MD5, root.stropheUtils);
@@ -1277,7 +1289,7 @@ function $pres(attrs) { return new Strophe.Builder("presence", attrs); }
  */
 Strophe = {
     /** Constant: VERSION */
-    VERSION: "1.2.14",
+    VERSION: "1.2.16",
 
     /** Constants: XMPP Namespace Constants
      *  Common namespace constants from the XMPP RFCs and XEPs.
@@ -1413,6 +1425,14 @@ Strophe = {
         ATTACHED: 8,
         REDIRECT: 9,
         CONNTIMEOUT: 10
+    },
+
+    ErrorCondition: {
+        BAD_FORMAT: "bad-format",
+        CONFLICT: "conflict",
+        MISSING_JID_NODE: "x-strophe-bad-non-anon-jid",
+        NO_AUTH_MECH: "no-auth-mech",
+        UNKNOWN_REASON: "unknown",
     },
 
     /** Constants: Log Level Constants
@@ -1991,7 +2011,7 @@ Strophe = {
      *
      *  This function is called whenever the Strophe library calls any
      *  of the logging functions.  The default implementation of this
-     *  function does nothing.  If client code wishes to handle the logging
+     *  function logs only fatal errors.  If client code wishes to handle the logging
      *  messages, it should override this with
      *  > Strophe.log = function (level, msg) {
      *  >   (user code here)
@@ -2015,11 +2035,13 @@ Strophe = {
      *      be one of the values in Strophe.LogLevel.
      *    (String) msg - The log message.
      */
-    /* jshint ignore:start */
     log: function (level, msg) {
-        return;
+        if (level === this.LogLevel.FATAL &&
+            typeof window.console === 'object' &&
+            typeof window.console.error === 'function') {
+            window.console.error(msg);
+        }
     },
-    /* jshint ignore:end */
 
     /** Function: debug
      *  Log a message at the Strophe.LogLevel.DEBUG level.
@@ -2685,10 +2707,11 @@ Strophe.TimedHandler.prototype = {
  *  If nothing is specified, then the following mechanisms (and their
  *  priorities) are registered:
  *
- *      OAUTHBEARER - 60
- *      SCRAM-SHA1 - 50
- *      DIGEST-MD5 - 40
- *      PLAIN - 30
+ *      SCRAM-SHA1 - 70
+ *      DIGEST-MD5 - 60
+ *      PLAIN - 50
+ *      OAUTH-BEARER - 40
+ *      OAUTH-2 - 30
  *      ANONYMOUS - 20
  *      EXTERNAL - 10
  *
@@ -3569,6 +3592,7 @@ Strophe.Connection.prototype = {
             Strophe.SASLExternal,
             Strophe.SASLMD5,
             Strophe.SASLOAuthBearer,
+            Strophe.SASLXOAuth2,
             Strophe.SASLPlain,
             Strophe.SASLSHA1
         ];
@@ -3635,8 +3659,9 @@ Strophe.Connection.prototype = {
      *    (Integer) status - the new connection status, one of the values
      *      in Strophe.Status
      *    (String) condition - the error condition or null
+     *    (XMLElement) elem - The triggering stanza.
      */
-    _changeConnectStatus: function (status, condition) {
+    _changeConnectStatus: function (status, condition, elem) {
         // notify all plugins listening for status changes
         for (var k in Strophe._connectionPlugins) {
             if (Strophe._connectionPlugins.hasOwnProperty(k)) {
@@ -3655,7 +3680,7 @@ Strophe.Connection.prototype = {
         // notify the user's callback
         if (this.connect_callback) {
             try {
-                this.connect_callback(status, condition);
+                this.connect_callback(status, condition, elem);
             } catch (e) {
                 Strophe._handleError(e);
                 Strophe.error(
@@ -3771,7 +3796,10 @@ Strophe.Connection.prototype = {
                 }
                 this._changeConnectStatus(Strophe.Status.CONNFAIL, cond);
             } else {
-                this._changeConnectStatus(Strophe.Status.CONNFAIL, "unknown");
+                this._changeConnectStatus(
+                    Strophe.Status.CONNFAIL,
+                    Strophe.ErrorCondition.UNKOWN_REASON
+                );
             }
             this._doDisconnect(cond);
             return;
@@ -3824,7 +3852,7 @@ Strophe.Connection.prototype = {
      *  Parameters:
      *    (Strophe.Request) req - The current request.
      *    (Function) _callback - low level (xmpp) connect callback function.
-     *      Useful for plugins with their own xmpp connect callback (when their)
+     *      Useful for plugins with their own xmpp connect callback (when they
      *      want to do something special).
      */
     _connect_cb: function (req, _callback, raw) {
@@ -3836,8 +3864,11 @@ Strophe.Connection.prototype = {
             bodyWrap = this._proto._reqToData(req);
         } catch (e) {
             if (e !== "badformat") { throw e; }
-            this._changeConnectStatus(Strophe.Status.CONNFAIL, 'bad-format');
-            this._doDisconnect('bad-format');
+            this._changeConnectStatus(
+                Strophe.Status.CONNFAIL,
+                Strophe.ErrorCondition.BAD_FORMAT
+            );
+            this._doDisconnect(Strophe.ErrorCondition.BAD_FORMAT);
         }
         if (!bodyWrap) { return; }
 
@@ -3982,9 +4013,9 @@ Strophe.Connection.prototype = {
             // client connections
             this._changeConnectStatus(
                 Strophe.Status.CONNFAIL,
-                'x-strophe-bad-non-anon-jid'
+                Strophe.ErrorCondition.MISSING_JID_NODE
             );
-            this.disconnect('x-strophe-bad-non-anon-jid');
+            this.disconnect(Strophe.ErrorCondition.MISSING_JID_NODE);
         } else {
             // Fall back to legacy authentication
             this._changeConnectStatus(Strophe.Status.AUTHENTICATING, null);
@@ -4202,9 +4233,9 @@ Strophe.Connection.prototype = {
             Strophe.info("SASL binding failed.");
             var conflict = elem.getElementsByTagName("conflict"), condition;
             if (conflict.length > 0) {
-                condition = 'conflict';
+                condition = Strophe.ErrorCondition.CONFLICT;
             }
-            this._changeConnectStatus(Strophe.Status.AUTHFAIL, condition);
+            this._changeConnectStatus(Strophe.Status.AUTHFAIL, condition, elem);
             return false;
         }
 
@@ -4231,7 +4262,7 @@ Strophe.Connection.prototype = {
             }
         } else {
             Strophe.info("SASL binding failed.");
-            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
             return false;
         }
     },
@@ -4254,7 +4285,7 @@ Strophe.Connection.prototype = {
             this._changeConnectStatus(Strophe.Status.CONNECTED, null);
         } else if (elem.getAttribute("type") === "error") {
             Strophe.info("Session creation failed.");
-            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
             return false;
         }
         return false;
@@ -4283,7 +4314,7 @@ Strophe.Connection.prototype = {
 
         if(this._sasl_mechanism)
           this._sasl_mechanism.onFailure();
-        this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+        this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
         return false;
     },
     /* jshint unused:true */
@@ -4305,7 +4336,7 @@ Strophe.Connection.prototype = {
             this.authenticated = true;
             this._changeConnectStatus(Strophe.Status.CONNECTED, null);
         } else if (elem.getAttribute("type") === "error") {
-            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null);
+            this._changeConnectStatus(Strophe.Status.AUTHFAIL, null, elem);
             this.disconnect('authentication failed');
         }
         return false;
@@ -4562,6 +4593,7 @@ Strophe.SASLMechanism.prototype = {
    *  Strophe.SASLSHA1 - SASL SCRAM-SHA1 authentication
    *  Strophe.SASLOAuthBearer - SASL OAuth Bearer authentication
    *  Strophe.SASLExternal - SASL EXTERNAL authentication
+   *  Strophe.SASLXOAuth2 - SASL X-OAuth2 authentication
    */
 
 // Building SASL callbacks
@@ -4581,7 +4613,7 @@ Strophe.SASLAnonymous.prototype.test = function(connection) {
  *  SASL PLAIN authentication.
  */
 Strophe.SASLPlain = function() {};
-Strophe.SASLPlain.prototype = new Strophe.SASLMechanism("PLAIN", true, 30);
+Strophe.SASLPlain.prototype = new Strophe.SASLMechanism("PLAIN", true, 50);
 
 Strophe.SASLPlain.prototype.test = function(connection) {
     return connection.authcid !== null;
@@ -4601,7 +4633,7 @@ Strophe.SASLPlain.prototype.onChallenge = function(connection) {
  *  SASL SCRAM SHA 1 authentication.
  */
 Strophe.SASLSHA1 = function() {};
-Strophe.SASLSHA1.prototype = new Strophe.SASLMechanism("SCRAM-SHA-1", true, 50);
+Strophe.SASLSHA1.prototype = new Strophe.SASLMechanism("SCRAM-SHA-1", true, 70);
 
 Strophe.SASLSHA1.prototype.test = function(connection) {
     return connection.authcid !== null;
@@ -4685,7 +4717,7 @@ Strophe.SASLSHA1.prototype.onChallenge = function(connection, challenge, test_cn
  *  SASL DIGEST MD5 authentication.
  */
 Strophe.SASLMD5 = function() {};
-Strophe.SASLMD5.prototype = new Strophe.SASLMechanism("DIGEST-MD5", false, 40);
+Strophe.SASLMD5.prototype = new Strophe.SASLMechanism("DIGEST-MD5", false, 60);
 
 Strophe.SASLMD5.prototype.test = function(connection) {
     return connection.authcid !== null;
@@ -4768,7 +4800,7 @@ Strophe.SASLMD5.prototype.onChallenge = function(connection, challenge, test_cno
  *  SASL OAuth Bearer authentication.
  */
 Strophe.SASLOAuthBearer = function() {};
-Strophe.SASLOAuthBearer.prototype = new Strophe.SASLMechanism("OAUTHBEARER", true, 60);
+Strophe.SASLOAuthBearer.prototype = new Strophe.SASLMechanism("OAUTHBEARER", true, 40);
 
 Strophe.SASLOAuthBearer.prototype.test = function(connection) {
     return connection.pass !== null;
@@ -4812,6 +4844,29 @@ Strophe.SASLExternal.prototype.onChallenge = function(connection) {
     return connection.authcid === connection.authzid ? '' : connection.authzid;
 };
 
+
+/** PrivateConstructor: SASLXOAuth2
+ *  SASL X-OAuth2 authentication.
+ */
+Strophe.SASLXOAuth2 = function () { };
+Strophe.SASLXOAuth2.prototype = new Strophe.SASLMechanism("X-OAUTH2", true, 30);
+
+Strophe.SASLXOAuth2.prototype.test = function (connection) {
+    return connection.pass !== null;
+};
+
+Strophe.SASLXOAuth2.prototype.onChallenge = function (connection) {
+    var auth_str = '\u0000';
+    if (connection.authcid !== null) {
+        auth_str = auth_str + connection.authzid;
+    }
+    auth_str = auth_str + "\u0000";
+    auth_str = auth_str + connection.pass;
+
+    return utils.utf16to8(auth_str);
+};
+
+
 return {
     'Strophe':         Strophe,
     '$build':          $build,
@@ -4845,6 +4900,10 @@ return {
                 core.$build
             );
         });
+    } else if (typeof exports === 'object') {
+        var core = require('./core');
+
+        module.exports = factory(core.Strophe, core.$build);
     } else {
         // Browser globals
         return factory(Strophe, $build);
@@ -4922,11 +4981,17 @@ Strophe.Request.prototype = {
                 throw "parsererror";
             }
         } else if (this.xhr.responseText) {
-            Strophe.error("invalid response received");
-            Strophe.error("responseText: " + this.xhr.responseText);
-            throw "badformat";
+            // In React Native, we may get responseText but no responseXML.  We can try to parse it manually.
+            Strophe.debug("Got responseText but no responseXML; attempting to parse it with DOMParser...");
+            node = new DOMParser().parseFromString(this.xhr.responseText, 'application/xml').documentElement;
+            if (!node) {
+                throw new Error('Parsing produced null node');
+            } else if (node.querySelector('parsererror')) {
+                Strophe.error("invalid response received: " + node.querySelector('parsererror').textContent);
+                Strophe.error("responseText: " + this.xhr.responseText);
+                throw "badformat";
+            }
         }
-
         return node;
     },
 
@@ -4991,6 +5056,8 @@ Strophe.Bosh = function(connection) {
     this.window = 5;
     this.errors = 0;
     this.inactivity = null;
+
+    this.lastResponseHeaders = null;
 
     this._requests = [];
 };
@@ -5304,18 +5371,22 @@ Strophe.Bosh.prototype = {
      * Called on stream start/restart when no stream:features
      * has been received and sends a blank poll request.
      */
-    _no_auth_received: function (_callback) {
-        if (_callback) {
-            _callback = _callback.bind(this._conn);
+    _no_auth_received: function (callback) {
+        Strophe.warn("Server did not yet offer a supported authentication "+
+                     "mechanism. Sending a blank poll request.");
+        if (callback) {
+            callback = callback.bind(this._conn);
         } else {
-            _callback = this._conn._connect_cb.bind(this._conn);
+            callback = this._conn._connect_cb.bind(this._conn);
         }
         var body = this._buildBody();
         this._requests.push(
-                new Strophe.Request(body.tree(),
-                    this._onRequestStateChange.bind(
-                        this, _callback.bind(this._conn)),
-                    body.tree().getAttribute("rid")));
+            new Strophe.Request(
+                body.tree(),
+                this._onRequestStateChange.bind(this, callback),
+                body.tree().getAttribute("rid")
+            )
+        );
         this._throttledRequestHandler();
     },
 
@@ -5459,6 +5530,7 @@ Strophe.Bosh.prototype = {
             return;
         }
         var reqStatus = this._getRequestStatus(req);
+        this.lastResponseHeaders = req.xhr.getAllResponseHeaders();
         if (this.disconnecting && reqStatus >= 400) {
             this._hitError(reqStatus);
             this._callProtocolErrorHandlers(req);
@@ -5783,6 +5855,10 @@ return Strophe;
                 core.$build
             );
         });
+    } else if (typeof exports === 'object') {
+        var core = require('./core');
+
+        module.exports = factory(core.Strophe, core.$build);
     } else {
         // Browser globals
         return factory(Strophe, $build);
@@ -6017,17 +6093,25 @@ Strophe.Websocket.prototype = {
                 this._connect_cb(streamStart);
             }
         } else if (message.data.indexOf("<close ") === 0) { // <close xmlns="urn:ietf:params:xml:ns:xmpp-framing />
+            // Parse the raw string to an XML element
+            var parsedMessage = new DOMParser().parseFromString(message.data, "text/xml").documentElement;
+            // Report this input to the raw and xml handlers
+            this._conn.xmlInput(parsedMessage);
             this._conn.rawInput(message.data);
-            this._conn.xmlInput(message);
-            var see_uri = message.getAttribute("see-other-uri");
+            var see_uri = parsedMessage.getAttribute("see-other-uri");
             if (see_uri) {
-                this._conn._changeConnectStatus(
-                    Strophe.Status.REDIRECT,
-                    "Received see-other-uri, resetting connection"
-                );
-                this._conn.reset();
-                this._conn.service = see_uri;
-                this._connect();
+                var service = this._conn.service;
+                // Valid scenarios: WSS->WSS, WS->ANY
+                var isSecureRedirect = (service.indexOf("wss:") >= 0 && see_uri.indexOf("wss:") >= 0) || (service.indexOf("ws:") >= 0);
+                if(isSecureRedirect) {
+                    this._conn._changeConnectStatus(
+                        Strophe.Status.REDIRECT,
+                        "Received see-other-uri, resetting connection"
+                    );
+                    this._conn.reset();
+                    this._conn.service = see_uri;
+                    this._connect();
+                }
             } else {
                 this._conn._changeConnectStatus(
                     Strophe.Status.CONNFAIL,
@@ -6057,7 +6141,7 @@ Strophe.Websocket.prototype = {
                 this._conn.send(pres);
             }
             var close = $build("close", { "xmlns": Strophe.NS.FRAMING });
-            this._conn.xmlOutput(close);
+            this._conn.xmlOutput(close.tree());
             var closeString = Strophe.serialize(close);
             this._conn.rawOutput(closeString);
             try {
@@ -6095,6 +6179,7 @@ Strophe.Websocket.prototype = {
      */
     _closeSocket: function () {
         if (this.socket) { try {
+            this.socket.onerror = null;
             this.socket.close();
         } catch (e) {} }
         this.socket = null;
@@ -6140,15 +6225,14 @@ Strophe.Websocket.prototype = {
      * Called on stream start/restart when no stream:features
      * has been received.
      */
-    _no_auth_received: function (_callback) {
-        Strophe.error("Server did not send any auth methods");
-        this._conn._changeConnectStatus(
+    _no_auth_received: function (callback) {
+        Strophe.error("Server did not offer a supported authentication mechanism");
+        this._changeConnectStatus(
             Strophe.Status.CONNFAIL,
-            "Server did not send any auth methods"
+            Strophe.ErrorCondition.NO_AUTH_MECH
         );
-        if (_callback) {
-            _callback = _callback.bind(this._conn);
-            _callback();
+        if (callback) {
+            callback.call(this._conn);
         }
         this._conn._doDisconnect();
     },
@@ -6328,6 +6412,11 @@ return Strophe;
         ], function (wrapper) {
             return wrapper;
         });
+    } else if (typeof exports === 'object') {
+        var core = require('./core');
+        require('./bosh');
+        require('./websocket');
+        module.exports = core;
     }
 })(this);
 


### PR DESCRIPTION
This change adds opt-in support (via a checkbox) for storing keys locally, as well as a list of authenticated users and their associated fingerprints.