### PR TITLE
Added basic text formatting

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,6 +29,7 @@
     <script type="application/javascript" src="js/lib/string_score.js"></script>
     <script type="application/javascript" src="js/lib/localforage.js"></script>
     <script type="application/javascript" src="js/lib/autolink.js"></script>
+    <script type="application/javascript" src="js/lib/textformatting.js"></script>
     <script type="application/javascript" src="js/cryptodog.js"></script>
     <script type="application/javascript" src="js/etc/ui.js"></script>
     <script type="application/javascript" src="js/etc/color.js"></script>

--- a/js/cryptodog.js
+++ b/js/cryptodog.js
@@ -195,6 +195,7 @@ Cryptodog.addToConversation = function(message, nickname, conversation, type) {
 		}
 		message = Strophe.xmlescape(message);
 		message = Cryptodog.UI.addLinks(message);
+		message = Cryptodog.UI.addTextFormatting(message);
 		message = Cryptodog.UI.addEmoticons(message);	
 	}
 	if (type === 'warning') {

--- a/js/etc/ui.js
+++ b/js/etc/ui.js
@@ -207,6 +207,11 @@ Cryptodog.UI = {
         return message.autoLink();
     },
 
+    // Contextual text formatting
+    addTextFormatting: function(message) {
+        return message.stylizeText();
+    },
+
     // Default emoticons (Unicode) - also in lang/emojis/unicode.json
     emoticons: [
         {

--- a/js/lib/textformatting.js
+++ b/js/lib/textformatting.js
@@ -1,0 +1,26 @@
+// Simple text formatting
+(function() {
+    stylizeText = function() {       
+        base = this
+
+        // Disable text formatting in messages that contain links to avoid interference
+        linkPattern = /(https?|ftps?):\/\//gi;
+
+        if (base.match(linkPattern) === null){
+            // Swap ***.+*** for strong and italic text
+            strongItalicPattern = /\*\*\*((?!\s).+)\*\*\*/gi;
+            base = base.replace(strongItalicPattern, "<strong><i>$1</i></strong>")
+
+            // Swap **.+** for strong text
+            strongPattern = /\*\*((?!\s).+)\*\*/gi;
+            base = base.replace(strongPattern, "<strong>$1</strong>")
+
+            // Swap *.+* for italics
+            italicPattern = /\*((?!\s).+)\*/gi;
+            base = base.replace(italicPattern, "<i>$1</i>")
+        }
+        return base;
+    };
+    String.prototype['stylizeText'] = stylizeText;
+}).call(this);
+  


### PR DESCRIPTION
*italics*
**bold**
***bold italics***

```
*italics*
**bold**
***bold italics***
```
 
Is not enabled in messages containing URL's, to prevent any possible conflicts.

![textformat](https://user-images.githubusercontent.com/61943481/76166805-668b8c00-612f-11ea-9835-b82816669027.PNG)
